### PR TITLE
Support irecovery 1.0.1

### DIFF
--- a/resources/device.sh
+++ b/resources/device.sh
@@ -10,7 +10,7 @@ FindDevice() {
     
     Log "Finding device in $1 mode..."
     while (( $i < $Timeout )); do
-        [[ $($irecovery -q 2>/dev/null | grep "MODE" | cut -c 7-) == "$1" ]] && DeviceIn=1
+        [[ $($irecovery -q 2>/dev/null | grep "MODE" | cut -c 7- | head -n 1) == "$1" ]] && DeviceIn=1
         if [[ $DeviceIn == 1 ]]; then
             Log "Found device in $1 mode."
             DeviceState="$1"
@@ -33,7 +33,7 @@ GetDeviceValues() {
     ideviceinfo2=$($ideviceinfo -s)
     if [[ $? != 0 ]]; then
         Log "Finding device in DFU/recovery mode..."
-        DeviceState="$($irecovery -q 2>/dev/null | grep "MODE" | cut -c 7-)"
+        DeviceState="$($irecovery -q 2>/dev/null | grep "MODE" | cut -c 7- | head -n 1)"
     else
         DeviceState="Normal"
     fi

--- a/resources/device.sh
+++ b/resources/device.sh
@@ -10,7 +10,7 @@ FindDevice() {
     
     Log "Finding device in $1 mode..."
     while (( $i < $Timeout )); do
-        [[ $($irecovery -q 2>/dev/null | grep "MODE" | cut -c 7- | head -n 1) == "$1" ]] && DeviceIn=1
+        [[ $($irecovery -q 2>/dev/null | grep -w "MODE" | cut -c 7-) == "$1" ]] && DeviceIn=1
         if [[ $DeviceIn == 1 ]]; then
             Log "Found device in $1 mode."
             DeviceState="$1"
@@ -33,7 +33,7 @@ GetDeviceValues() {
     ideviceinfo2=$($ideviceinfo -s)
     if [[ $? != 0 ]]; then
         Log "Finding device in DFU/recovery mode..."
-        DeviceState="$($irecovery -q 2>/dev/null | grep "MODE" | cut -c 7- | head -n 1)"
+        DeviceState="$($irecovery -q 2>/dev/null | grep -w "MODE" | cut -c 7-"
     else
         DeviceState="Normal"
     fi


### PR DESCRIPTION
```
$ irecovery -q
...
MODE: Recovery
...
MODEL: j72ap
```
`grep "MODE"` catches MODEL
```
Recovery
 j72ap
```
`grep -w "MODE"` does not
```
Recovery
```