### PR TITLE
Update ssh_config

### DIFF
--- a/resources/ssh_config
+++ b/resources/ssh_config
@@ -1,3 +1,6 @@
-StrictHostKeyChecking no
-UserKnownHostsFile tmp/known_hosts
-HostKeyAlgorithms=+ssh-rsa
+Host *
+    AddKeysToAgent yes
+    IdentitiesOnly yes
+    StrictHostKeyChecking no
+    UserKnownHostsFile /dev/null
+    HostKeyAlgorithms +ssh-rsa


### PR DESCRIPTION
Best to change UserKnownHostsFile to /dev/null rather than a persistent (or temp) file. Then there's nothing to tell the user to delete if they hit an issue there.
    AddKeysToAgent yes
    IdentitiesOnly yes
Both required for successful connection under Catalina/OpenSSH_8.1p1, LibreSSL 2.7.3

Reported in #156 