### PR TITLE
Correct casing for iPhone 5s and iPhone 5c

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ## Supported devices
 - [Identify your device here](https://ipsw.me/device-finder)
-- **iPhone 5C and iPad mini 3 devices are NOT supported by OTA downgrades**
+- **iPhone 5c and iPad mini 3 devices are NOT supported by OTA downgrades**
     - These devices still support restoring to other iOS versions with SHSH blobs
 - **iPhone4Down (downgrading without blobs) supports iPhone 4 GSM only (iPhone3,1)**
     - All iPhone 4 models still support restoring with SHSH blobs and to iOS 7.1.2

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
             <td rowspan=4>iOS 10.3.3</td>
             <td><b>A7 devices:</b></td>
         </tr>
-        <tr><td>iPhone 5S</td></tr>
+        <tr><td>iPhone 5s</td></tr>
         <tr><td>iPad Air 1</td></tr>
         <tr><td>iPad mini 2 (except iPad4,6)</td></tr>
         <tr>


### PR DESCRIPTION
iPhone 5s and 5c have lowercase stylized casing. 
5s: https://support.apple.com/kb/sp685?locale=en_CA
5c: https://support.apple.com/kb/sp684?locale=en_CA