### PR TITLE
Fix bug: Wrong highest firmware for iPad3,4; iPhone5,3; and iPhone5,4

### DIFF
--- a/restore.sh
+++ b/restore.sh
@@ -1531,7 +1531,11 @@ device_get_info() {
             device_use_vers="9.3.6"
             device_use_build="13G37"
         ;;
-        iPad3,[456] | iPhone5,[1234] )
+        iPad3,4 | iPhone5,[34] )
+            device_use_vers="10.3.4"
+            device_use_build="14G60"
+        ;;
+        iPad3,[56] | iPhone5,[12] )
             device_use_vers="10.3.4"
             device_use_build="14G61"
         ;;


### PR DESCRIPTION
Line 1534 showed that all models of iPad 4 and iPhone 5(c) share the highest firmware of 10.3.4, which isn't true according to ipsw.me.

Additional suggestion: Instead of hard-coding the values into the script, always query ipsw.me to check for the latest firmware of a particular model.